### PR TITLE
made spinner more reusable.

### DIFF
--- a/code/container/Spinner.kt
+++ b/code/container/Spinner.kt
@@ -17,7 +17,10 @@ private fun SpinnerExample() {
         text = text,
         expanded = expanded,
         list = itemList,
-        onItemClick = { text = it },
+        onItemClick = {
+            text = it
+            expanded = false
+        },
         onClick = {
             expanded = it
         }
@@ -50,7 +53,6 @@ private fun Spinner(
                 DropdownMenuItem(
                     onClick = {
                         onItemClick?.invoke(item)
-                        onClick?.invoke(false)
                     }
                 ) {
                     Text(text = item)

--- a/code/container/Spinner.kt
+++ b/code/container/Spinner.kt
@@ -1,5 +1,5 @@
 @Composable
-private fun SpinnerExample() {
+fun SpinnerExample() {
 
     val itemList = listOf(
         "Berlin",
@@ -28,7 +28,7 @@ private fun SpinnerExample() {
 }
 
 @Composable
-private fun Spinner(
+fun Spinner(
     text: String = "Select something!",
     expanded: Boolean = false,
     list: List<String>,
@@ -37,16 +37,16 @@ private fun Spinner(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.clickable { onClick() }
+        modifier = Modifier.clickable(onClick = onClick)
     ) {
         Text(text = text, )
         Icon(
             imageVector = Icons.Filled.ArrowDropDown,
-            contentDescription = "",
+            contentDescription = "ArrowDropDown",
         )
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { onClick() }
+            onDismissRequest = onClick
         ) {
             list.forEach { item ->
 

--- a/code/container/Spinner.kt
+++ b/code/container/Spinner.kt
@@ -9,35 +9,48 @@ private fun SpinnerExample() {
         "Düsseldorf",
         "Osnabrück"
     )
-    Spinner(text = "Select a city!", itemList)
+
+    var text by remember { mutableStateOf("Select a city!") }
+    var expanded by remember { mutableStateOf(false) }
+
+    Spinner(
+        text = text,
+        expanded = expanded,
+        list = itemList,
+        onItemClick = { text = it },
+        onClick = {
+            expanded = it
+        }
+    )
 }
 
 @Composable
 private fun Spinner(
     text: String = "Select something!",
+    expanded: Boolean = false,
     list: List<String>,
-    onClick: ((String) -> Unit)? = null
+    onItemClick: ((String) -> Unit)? = null,
+    onClick: ((Boolean) -> Unit)? = null
 ) {
-    var shownText by remember { mutableStateOf(text) }
-    var expanded by remember { mutableStateOf(false) }
-
-    // The Row aligns text and icon
     Row(
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(text = shownText, Modifier.clickable { expanded = !expanded })
-        Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "")
+        Text(text = text, Modifier.clickable { onClick?.invoke(!expanded) })
+        Icon(
+            imageVector = Icons.Filled.ArrowDropDown,
+            contentDescription = "",
+            modifier = Modifier.clickable { onClick?.invoke(!expanded) }
+        )
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { expanded = false }
+            onDismissRequest = { onClick?.invoke(false) }
         ) {
             list.forEach { item ->
 
                 DropdownMenuItem(
                     onClick = {
-                        expanded = false
-                        shownText = item
-                        onClick?.invoke(item)
+                        onItemClick?.invoke(item)
+                        onClick?.invoke(false)
                     }
                 ) {
                     Text(text = item)

--- a/code/container/Spinner.kt
+++ b/code/container/Spinner.kt
@@ -22,7 +22,7 @@ private fun SpinnerExample() {
             expanded = false
         },
         onClick = {
-            expanded = it
+            expanded = !expanded
         }
     )
 }
@@ -33,20 +33,20 @@ private fun Spinner(
     expanded: Boolean = false,
     list: List<String>,
     onItemClick: ((String) -> Unit)? = null,
-    onClick: ((Boolean) -> Unit)? = null
+    onClick: () -> Unit
 ) {
     Row(
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.clickable { onClick() }
     ) {
-        Text(text = text, Modifier.clickable { onClick?.invoke(!expanded) })
+        Text(text = text, )
         Icon(
             imageVector = Icons.Filled.ArrowDropDown,
             contentDescription = "",
-            modifier = Modifier.clickable { onClick?.invoke(!expanded) }
         )
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { onClick?.invoke(false) }
+            onDismissRequest = { onClick() }
         ) {
             list.forEach { item ->
 

--- a/code/container/Spinner.kt
+++ b/code/container/Spinner.kt
@@ -1,5 +1,5 @@
 @Composable
-fun SpinnerExample() {
+private fun SpinnerExample() {
 
     val itemList = listOf(
         "Berlin",
@@ -9,32 +9,38 @@ fun SpinnerExample() {
         "Düsseldorf",
         "Osnabrück"
     )
+    Spinner(text = "Select a city!", itemList)
+}
 
+@Composable
+private fun Spinner(
+    text: String = "Select something!",
+    list: List<String>,
+    onClick: ((String) -> Unit)? = null
+) {
+    var shownText by remember { mutableStateOf(text) }
     var expanded by remember { mutableStateOf(false) }
-    var cityname by remember { mutableStateOf("select a city") }
 
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+    // The Row aligns text and icon
+    Row(
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        // The Row aligns text and icon
-        Row {
-            Text(text = cityname, Modifier.clickable { expanded = !expanded })
-            Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "")
-            DropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false }
-            ) {
-                itemList.forEach { city ->
+        Text(text = shownText, Modifier.clickable { expanded = !expanded })
+        Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "")
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            list.forEach { item ->
 
-                    DropdownMenuItem(
-                        onClick = {
-                            expanded = false
-                            cityname = city
-                        }
-                    ) {
-                        Text(text = city)
+                DropdownMenuItem(
+                    onClick = {
+                        expanded = false
+                        shownText = item
+                        onClick?.invoke(item)
                     }
+                ) {
+                    Text(text = item)
                 }
             }
         }

--- a/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
+++ b/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
@@ -82,7 +82,7 @@ private fun SpinnerExample() {
 }
 
 @Composable
-private fun Spinner(
+fun Spinner(
     text: String = "Select something!",
     expanded: Boolean = false,
     list: List<String>,
@@ -91,16 +91,16 @@ private fun Spinner(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.clickable { onClick() }
+        modifier = Modifier.clickable(onClick = onClick)
     ) {
         Text(text = text, )
         Icon(
             imageVector = Icons.Filled.ArrowDropDown,
-            contentDescription = "",
+            contentDescription = "ArrowDropDown",
         )
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { onClick() }
+            onDismissRequest = onClick
         ) {
             list.forEach { item ->
 

--- a/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
+++ b/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import de.check24.compose.demo.theme.DemoTheme
-import kotlin.math.exp
 
 class ComposableSpinnerActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -72,7 +71,10 @@ private fun SpinnerExample() {
         text = text,
         expanded = expanded,
         list = itemList,
-        onItemClick = { text = it },
+        onItemClick = {
+            text = it
+            expanded = false
+        },
         onClick = {
             expanded = it
         }
@@ -105,7 +107,6 @@ private fun Spinner(
                 DropdownMenuItem(
                     onClick = {
                         onItemClick?.invoke(item)
-                        onClick?.invoke(false)
                     }
                 ) {
                     Text(text = item)

--- a/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
+++ b/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.DropdownMenu
@@ -41,7 +39,12 @@ class ComposableSpinnerActivity : ComponentActivity() {
                             }
                         )
                     }, content = {
-                        SpinnerExample()
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            SpinnerExample()
+                        }
                     }
                 )
             }
@@ -60,32 +63,37 @@ private fun SpinnerExample() {
         "Düsseldorf",
         "Osnabrück"
     )
+    Spinner(text = "Select a city!", itemList)
+}
 
+@Composable
+private fun Spinner(
+    text: String = "Select something!",
+    list: List<String>,
+    onClick: ((String) -> Unit)? = null
+) {
+    var shownText by remember { mutableStateOf(text) }
     var expanded by remember { mutableStateOf(false) }
-    var cityname by remember { mutableStateOf("select a city") }
 
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+    Row(
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        // The Row aligns text and icon
-        Row {
-            Text(text = cityname, Modifier.clickable { expanded = !expanded })
-            Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "")
-            DropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false }
-            ) {
-                itemList.forEach { city ->
+        Text(text = shownText, Modifier.clickable { expanded = !expanded })
+        Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "")
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            list.forEach { item ->
 
-                    DropdownMenuItem(
-                        onClick = {
-                            expanded = false
-                            cityname = city
-                        }
-                    ) {
-                        Text(text = city)
+                DropdownMenuItem(
+                    onClick = {
+                        expanded = false
+                        shownText = item
+                        onClick?.invoke(item)
                     }
+                ) {
+                    Text(text = item)
                 }
             }
         }

--- a/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
+++ b/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import de.check24.compose.demo.theme.DemoTheme
+import kotlin.math.exp
 
 class ComposableSpinnerActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -63,34 +64,48 @@ private fun SpinnerExample() {
         "Düsseldorf",
         "Osnabrück"
     )
-    Spinner(text = "Select a city!", itemList)
+
+    var text by remember { mutableStateOf("Select a city!") }
+    var expanded by remember { mutableStateOf(false) }
+
+    Spinner(
+        text = text,
+        expanded = expanded,
+        list = itemList,
+        onItemClick = { text = it },
+        onClick = {
+            expanded = it
+        }
+    )
 }
 
 @Composable
 private fun Spinner(
     text: String = "Select something!",
+    expanded: Boolean = false,
     list: List<String>,
-    onClick: ((String) -> Unit)? = null
+    onItemClick: ((String) -> Unit)? = null,
+    onClick: ((Boolean) -> Unit)? = null
 ) {
-    var shownText by remember { mutableStateOf(text) }
-    var expanded by remember { mutableStateOf(false) }
-
     Row(
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(text = shownText, Modifier.clickable { expanded = !expanded })
-        Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = "")
+        Text(text = text, Modifier.clickable { onClick?.invoke(!expanded) })
+        Icon(
+            imageVector = Icons.Filled.ArrowDropDown,
+            contentDescription = "",
+            modifier = Modifier.clickable { onClick?.invoke(!expanded) }
+        )
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { expanded = false }
+            onDismissRequest = { onClick?.invoke(false) }
         ) {
             list.forEach { item ->
 
                 DropdownMenuItem(
                     onClick = {
-                        expanded = false
-                        shownText = item
-                        onClick?.invoke(item)
+                        onItemClick?.invoke(item)
+                        onClick?.invoke(false)
                     }
                 ) {
                     Text(text = item)

--- a/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
+++ b/demo/src/main/java/de/check24/compose/demo/features/spinner/ComposableSpinnerActivity.kt
@@ -76,7 +76,7 @@ private fun SpinnerExample() {
             expanded = false
         },
         onClick = {
-            expanded = it
+            expanded = !expanded
         }
     )
 }
@@ -87,20 +87,20 @@ private fun Spinner(
     expanded: Boolean = false,
     list: List<String>,
     onItemClick: ((String) -> Unit)? = null,
-    onClick: ((Boolean) -> Unit)? = null
+    onClick: () -> Unit
 ) {
     Row(
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.clickable { onClick() }
     ) {
-        Text(text = text, Modifier.clickable { onClick?.invoke(!expanded) })
+        Text(text = text, )
         Icon(
             imageVector = Icons.Filled.ArrowDropDown,
             contentDescription = "",
-            modifier = Modifier.clickable { onClick?.invoke(!expanded) }
         )
         DropdownMenu(
             expanded = expanded,
-            onDismissRequest = { onClick?.invoke(false) }
+            onDismissRequest = { onClick() }
         ) {
             list.forEach { item ->
 


### PR DESCRIPTION
I know that stateful composables are not preferred. Nevertheless I think when using the spinner, it's more convenient, if you don't have to care about the expanding and remembering of the selected word. I just don't see a sensible reason why one would want to manage the state in the parent in this case. It just brings in 90% of the cases boilerplate code to the parent. Nevertheless, I am happy to be convinced otherwise.